### PR TITLE
New Skill class for skills that are controlled via OPC UA variables

### DIFF
--- a/Machine-Capability-Model.owl
+++ b/Machine-Capability-Model.owl
@@ -35,6 +35,12 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description_has_Type -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description_has_Type"/>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/VDI3682#TechnicalResourceIsAssignedToProcessOperator -->
 
     <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/VDI3682#TechnicalResourceIsAssignedToProcessOperator">
@@ -65,6 +71,15 @@
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#IrreflexiveProperty"/>
         <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#Skill"/>
         <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/ISA-TR88#State"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasCurrentStateOutput -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasCurrentStateOutput">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillOutput"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput"/>
     </owl:ObjectProperty>
     
 
@@ -102,6 +117,15 @@
 
     <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasReason">
         <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#Dependency"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasSkillCommand -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillCommand">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillParameter"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommand"/>
     </owl:ObjectProperty>
     
 
@@ -226,11 +250,29 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaMethodSkill -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaMethodSkill">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaSkill"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaMethodSkill"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaSkill -->
 
     <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaSkill">
         <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaSkill"/>
         <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaSkill"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaVariableSkill -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaVariableSkill">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#isExecutableViaOpcUaSkill"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaVariableSkill"/>
     </owl:ObjectProperty>
     
 
@@ -253,11 +295,29 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaMethodSkill -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaMethodSkill">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaSkill"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaMethodSkill"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaSkill -->
 
     <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaSkill">
         <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#providesSkill"/>
         <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaSkill"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaVariableSkill -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaVariableSkill">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#providesOpcUaSkill"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaVariableSkill"/>
     </owl:ObjectProperty>
     
 
@@ -290,6 +350,42 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Definition -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Definition"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Expression_Goal -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Expression_Goal"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Logic_Interpretation -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Logic_Interpretation"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Note -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Note"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Preferred_Name -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Preferred_Name"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Value -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Value"/>
     
 
 
@@ -398,6 +494,24 @@
     <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/DIN8580#Fertigungsverfahren">
         <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/VDI3682#Process"/>
     </rdf:Description>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Data_Element -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Data_Element"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/DINEN61360#Type_Description -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/DINEN61360#Type_Description"/>
     
 
 
@@ -547,6 +661,14 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillOutput"/>
+    </owl:Class>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#Dependency -->
 
     <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Dependency"/>
@@ -687,14 +809,6 @@
     
 
 
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillStateOutput -->
-
-    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillStateOutput">
-        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillOutput"/>
-    </owl:Class>
-    
-
-
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillVariable -->
 
     <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillVariable"/>
@@ -818,13 +932,325 @@ In the future, there could also be multiple DataProperties for a SkillParameterO
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Type_Description"/>
+        <DINEN61360:Definition xml:lang="en">A CurrentStateOutput is an integer OpcUa Variable that is used to reflect the current state of the state machine.</DINEN61360:Definition>
+        <DINEN61360:Note xml:lang="en">Note that there should always be instance descriptions connected to this type description that are connected to the states of the state machine in order to specify which value reflects a certain state.</DINEN61360:Note>
+        <DINEN61360:Preferred_Name xml:lang="en">CurrentStateOutput</DINEN61360:Preferred_Name>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Abort -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Abort">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>256</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Complete -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Complete">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>1024</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Hold -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Hold">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>16</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Pause -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Pause">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>64</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Reset -->
 
     <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Reset">
         <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
-        <DINEN61360:Expression_Goal xml:lang="en">Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
         <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
-        <DINEN61360:Value xml:lang="en">2</DINEN61360:Value>
+        <DINEN61360:Value>2</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Restart -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Restart">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>512</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Resume -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Resume">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>128</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Start -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Start">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>4</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Stop -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Stop">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value>8</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Unhold -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Unhold">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD"/>
+        <DINEN61360:Expression_Goal>Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Aborted -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Aborted">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">512</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Aborting -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Aborting">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">256</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Completed -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Completed">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">131072</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Completing -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Completing">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">65536</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Execute -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Execute">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">64</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Held -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Held">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2048</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Holding -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Holding">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1024</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Idle -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Idle">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Paused -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Paused">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Pausing -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Pausing">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8192</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Resetting -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Resetting">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">32768</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Resuming -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Resuming">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">16384</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Starting -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Starting">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">8</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Stopped -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Stopped">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Stopping -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Stopping">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">128</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Unholding -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_CurrentState_Unholding">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Instance_Description_has_Type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#CurrentStateOutput_TD"/>
+        <DINEN61360:Expression_Goal>Assurance</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4096</DINEN61360:Value>
     </owl:NamedIndividual>
     
 
@@ -834,7 +1260,7 @@ In the future, there could also be multiple DataProperties for a SkillParameterO
     <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD">
         <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Type_Description"/>
         <DINEN61360:Definition xml:lang="en">A SkillCommandVariable is an OpcUa Variable that is used to trigger transitions of the state machine. It can be seen as the counterpart to methods of an OpcUaMethodSkill.</DINEN61360:Definition>
-        <DINEN61360:Note xml:lang="en">Note that there should always be instances of this Type Definition connected to the transitions of the state machine in order to specify which values have to be used to trigger a transition.</DINEN61360:Note>
+        <DINEN61360:Note xml:lang="en">Note that there should always be instance descriptions of this type description connected to the transitions of the state machine in order to specify which values have to be used to trigger a transition.</DINEN61360:Note>
         <DINEN61360:Preferred_Name xml:lang="en">SkillCommandVariable</DINEN61360:Preferred_Name>
     </owl:NamedIndividual>
     
@@ -867,47 +1293,6 @@ In the future, there could also be multiple DataProperties for a SkillParameterO
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#TriggerParallel -->
 
     <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#TriggerParallel"/>
-    
-
-
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#someCommand -->
-
-    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#someCommand">
-        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/ISA-TR88#Start_Command"/>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#someConjunction -->
-
-    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#someConjunction">
-        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#DependencySourceConjunction"/>
-        <capability-model:hasDependencySource rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#someOtherState"/>
-        <capability-model:hasDependencySource rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#someState"/>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#someDependency -->
-
-    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#someDependency">
-        <capability-model:hasDependencySource rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#someState"/>
-        <capability-model:hasDependencyTarget rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#someCommand"/>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#someOtherState -->
-
-    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#someOtherState"/>
-    
-
-
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#someState -->
-
-    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#someState">
-        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/ISA-TR88#Idle"/>
-    </owl:NamedIndividual>
     
 
 

--- a/Machine-Capability-Model.owl
+++ b/Machine-Capability-Model.owl
@@ -8,6 +8,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:OpcUa="http://www.hsu-ifa.de/ontologies/OpcUa#"
      xmlns:swrla="http://swrl.stanford.edu/ontologies/3.3/swrla.owl#"
+     xmlns:DINEN61360="http://www.hsu-ifa.de/ontologies/DINEN61360#"
      xmlns:capability-model="http://www.hsu-ifa.de/ontologies/capability-model#">
     <owl:Ontology rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#">
         <owl:versionIRI rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model/1.0.0#"/>
@@ -45,7 +46,7 @@
     <!-- http://www.hsu-ifa.de/ontologies/WADL#hasParameterOption -->
 
     <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/WADL#hasParameterOption">
-        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillParameterOption"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillVariableOption"/>
     </rdf:Description>
     
 
@@ -105,6 +106,15 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasSkillMethod -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillMethod">
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#Skill"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillMethod"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasSkillOutput -->
 
     <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillOutput">
@@ -125,21 +135,21 @@
     
 
 
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasSkillParameterOption -->
-
-    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillParameterOption">
-        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillParameter"/>
-        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillParameterOption"/>
-        <rdfs:comment></rdfs:comment>
-    </owl:ObjectProperty>
-    
-
-
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasSkillVariable -->
 
     <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillVariable">
         <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#Skill"/>
         <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillVariable"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasSkillVariableOption -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasSkillVariableOption">
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillParameter"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillVariableOption"/>
+        <rdfs:comment></rdfs:comment>
     </owl:ObjectProperty>
     
 
@@ -283,6 +293,14 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/WADL#hasOptionValue -->
+
+    <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/WADL#hasOptionValue">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#hasOptionValue"/>
+    </rdf:Description>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/WADL#hasParameterDefault -->
 
     <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/WADL#hasParameterDefault">
@@ -327,7 +345,9 @@
 
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#hasOptionValue -->
 
-    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasOptionValue"/>
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#hasOptionValue">
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillVariableOption"/>
+    </owl:DatatypeProperty>
     
 
 
@@ -484,7 +504,7 @@
     <!-- http://www.hsu-ifa.de/ontologies/WADL#Option -->
 
     <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/WADL#Option">
-        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillParameterOption"/>
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillVariableOption"/>
     </rdf:Description>
     
 
@@ -505,9 +525,25 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Abort -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Abort">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#Capability -->
 
     <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Capability"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Clear -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Clear">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
     
 
 
@@ -559,10 +595,50 @@
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#GetOutputs -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#GetOutputs">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatelessMethod"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Hold -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Hold">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#OpcUaMethodSkill -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaMethodSkill">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaSkill"/>
+    </owl:Class>
+    
+
+
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#OpcUaSkill -->
 
     <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaSkill">
         <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#Skill"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#OpcUaVariableSkill -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaVariableSkill">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#OpcUaSkill"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Reset -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Reset">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
     </owl:Class>
     
 
@@ -578,6 +654,20 @@
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#Skill -->
 
     <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Skill"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillCommand -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommand">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillParameter"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillMethod -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillMethod"/>
     
 
 
@@ -597,12 +687,10 @@
     
 
 
-    <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillParameterOption -->
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillStateOutput -->
 
-    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillParameterOption">
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Please note that SkillParameterOption currently only has an option value so there is no real need for an extra individual. Option values could directly be attached to a SkillParameter.
-This class was created to be compliant with WADL where an Option individual has multiple data properties attached. 
-In the future, there could also be multiple DataProperties for a SkillParameterOption</rdfs:comment>
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillStateOutput">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillOutput"/>
     </owl:Class>
     
 
@@ -610,6 +698,56 @@ In the future, there could also be multiple DataProperties for a SkillParameterO
     <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillVariable -->
 
     <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillVariable"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillVariableOption -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillVariableOption">
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Please note that SkillParameterOption currently only has an option value so there is no real need for an extra individual. Option values could directly be attached to a SkillParameter.
+This class was created to be compliant with WADL where an Option individual has multiple data properties attached. 
+In the future, there could also be multiple DataProperties for a SkillParameterOption</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Start -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Start">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillMethod"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#StatelessMethod -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#StatelessMethod">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#SkillMethod"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Stop -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Stop">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Suspend -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Suspend">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
     
 
 
@@ -653,6 +791,22 @@ In the future, there could also be multiple DataProperties for a SkillParameterO
     
 
 
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Unhold -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Unhold">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#Unsuspend -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#Unsuspend">
+        <rdfs:subClassOf rdf:resource="http://www.hsu-ifa.de/ontologies/capability-model#StatefulMethod"/>
+    </owl:Class>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -661,6 +815,28 @@ In the future, there could also be multiple DataProperties for a SkillParameterO
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Reset -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#MTP_Command_Reset">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Instance_Description"/>
+        <DINEN61360:Expression_Goal xml:lang="en">Requirement</DINEN61360:Expression_Goal>
+        <DINEN61360:Logic_Interpretation>=</DINEN61360:Logic_Interpretation>
+        <DINEN61360:Value xml:lang="en">2</DINEN61360:Value>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/ontologies/capability-model#SkillCommandVariable_TD">
+        <rdf:type rdf:resource="http://www.hsu-ifa.de/ontologies/DINEN61360#Type_Description"/>
+        <DINEN61360:Definition xml:lang="en">A SkillCommandVariable is an OpcUa Variable that is used to trigger transitions of the state machine. It can be seen as the counterpart to methods of an OpcUaMethodSkill.</DINEN61360:Definition>
+        <DINEN61360:Note xml:lang="en">Note that there should always be instances of this Type Definition connected to the transitions of the state machine in order to specify which values have to be used to trigger a transition.</DINEN61360:Note>
+        <DINEN61360:Preferred_Name xml:lang="en">SkillCommandVariable</DINEN61360:Preferred_Name>
+    </owl:NamedIndividual>
     
 
 


### PR DESCRIPTION
This PR brings some "breaking changes":
* The class OpcUaSkill is now a super class for OpcUaMethodSkills and OpcUaVariableSkills. OpcUaMethodSkills are what was previously called OpcUaSkill: Skills that can be controlled via OPC UA Methods. An OpcUaVariableSkill is controlled by setting an OPC UA Variable to a certain integer value
* The class OpcUaSkill is used to map services of a Module Type Package  (MTP).
* Required values have been added to specify the value that has to be set in order to invoke a certain transition (conforming to MTP standard)
* Assured values have been added to specify the value that are returned as a feedback of the current state (conforming to MTP standard)